### PR TITLE
Changed ownership of files under promoter and rdoinfo homes

### DIFF
--- a/manifests/promoter.pp
+++ b/manifests/promoter.pp
@@ -12,6 +12,12 @@ class delorean::promoter (
     home       => '/home/promoter',
     managehome => true,
   } ->
+  file { '/home/promoter':
+    ensure  => directory,
+    owner   => 'promoter',
+    group   => 'promoter',
+    recurse => true,
+  } ->
   file { '/home/promoter/.ssh':
     ensure => directory,
     mode   => '0700',

--- a/manifests/rdoinfo.pp
+++ b/manifests/rdoinfo.pp
@@ -17,6 +17,11 @@ class delorean::rdoinfo (
     mode   => '0755',
     owner  => 'rdoinfo',
   } ->
+  exec { 'ensure home contents belong to rdoinfo':
+    command => 'chown -R rdoinfo:rdoinfo /home/rdoinfo',
+    path    => '/usr/bin',
+    timeout => 100,
+  } ->
   vcsrepo { '/home/rdoinfo/rdoinfo':
     ensure   => present,
     provider => git,

--- a/spec/classes/delorean_promoter_spec.rb
+++ b/spec/classes/delorean_promoter_spec.rb
@@ -15,6 +15,15 @@ describe 'delorean::promoter' do
     it 'creates user promoter' do
       is_expected.to contain_user('promoter').with(
         :managehome => 'true'
+      ).with_before(/File\[\/home\/promoter/)
+    end
+
+    it 'creates /home/promoter' do
+      is_expected.to contain_file('/home/promoter').with(
+        :ensure  => 'directory',
+        :owner   => 'promoter',
+        :group   => 'promoter',
+        :recurse => true,
       ).with_before(/File\[\/home\/promoter\/.ssh/)
     end
 

--- a/spec/classes/delorean_rdoinfo_spec.rb
+++ b/spec/classes/delorean_rdoinfo_spec.rb
@@ -24,7 +24,7 @@ describe 'delorean::rdoinfo' do
         :ensure => 'directory',
         :owner  => 'rdoinfo',
         :mode   => '0755',
-      ).with_before(/Vcsrepo\[\/home\/rdoinfo\/rdoinfo\]/)
+      ).with_before(/Exec\[ensure home contents belong to rdoinfo\]/)
     end
 
     it 'clones the rdoinfo git repo' do


### PR DESCRIPTION
When restoring content of /home/promoter or /home/rdoinfo from a
previous server build, they may have different uid or gid. This patch
change ownership to the right user/groups.

Fixes #12