### PR TITLE
Use Mitaka testing repo

### DIFF
--- a/files/centos-master-delorean-deps.repo
+++ b/files/centos-master-delorean-deps.repo
@@ -1,6 +1,6 @@
-[delorean-liberty-testing]
-name=delorean-liberty-testing
-baseurl=http://buildlogs.centos.org/centos/7/cloud/$basearch/openstack-liberty/
+[delorean-mitaka-testing]
+name=delorean-mitaka-testing
+baseurl=http://buildlogs.centos.org/centos/7/cloud/$basearch/openstack-mitaka/
 enabled=1
 gpgcheck=0
 priority=2

--- a/files/centos-mitaka-delorean-deps.repo
+++ b/files/centos-mitaka-delorean-deps.repo
@@ -1,6 +1,6 @@
-[delorean-liberty-testing]
-name=delorean-liberty-testing
-baseurl=http://buildlogs.centos.org/centos/7/cloud/$basearch/openstack-liberty/
+[delorean-mitaka-testing]
+name=delorean-mitaka-testing
+baseurl=http://buildlogs.centos.org/centos/7/cloud/$basearch/openstack-mitaka/
 enabled=1
 gpgcheck=0
 priority=2


### PR DESCRIPTION
For Mitaka and Master workers.
For Master we might want to create newton-testing early or create new
common-only repo on buildlogs to avoid complaints from folks looking
inside delorean-deps.repo