### PR TITLE
Added support for rsync push

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,12 @@ This is a user to run Gerrit reviews for packages after build failures. If set t
 ####`gerrit_email` 
 This is the email for the user to run Gerrit reviews for packages after build failures. It is required when `gerrit_user` is set, and ignored otherwise.
 
+###`rsyncdest`
+This is the destination where builtdir and reports are replicated when build is ok in scp-like format. Defaults to `undef`, which means that replication is disabled.
+
+###`rsyncport`
+This is the port number for ssh in server where builtdir and reports are replicated. Defaults to `22`.
+
 ## Limitations
 
 The module has been tested on Fedora and CentOS.

--- a/examples/common.yaml
+++ b/examples/common.yaml
@@ -15,6 +15,8 @@ dlrn::workers:
     release: 'mitaka'
 #   gerrit_user: 'rdo-trunk'
 #   gerrit_email: 'rdo-trunk@rdoproject.org'
+#   rsyncdest: 'centos-master@backupserver.example.com:/home/centos-master/data/repos'
+#   rsyncport: '3000'
   centos-mitaka:
     name: 'centos-mitaka'
     distro: 'centos7'

--- a/manifests/worker.pp
+++ b/manifests/worker.pp
@@ -51,6 +51,18 @@
 #   Example: 'rdo-trunk@rdoproject.org'
 #   Defaults to undef
 # 
+# [*rsyncdest*]
+#   (optional) destination where builtdir and reports are replicated when build is ok. 
+#     format: <user>@<ip or hostname>:<destdir>
+#   Example: 'centos-master@backupserver.example.com:/home/centos-master/data/repos'
+#   Defaults to undef
+#
+# [*rsyncport*]
+#   (optional) port number for ssh in server where builtdir and reports are copied
+#     after built is successfull.
+#   Example: '22'
+#   Defaults to '22'
+#
 # === Example
 #
 #  dlrn::worker {'centos-master':
@@ -75,7 +87,9 @@ define dlrn::worker (
   $symlinks       = undef,
   $release        = 'mitaka',
   $gerrit_user    = undef,
-  $gerrit_email   = undef ) {
+  $gerrit_email   = undef,
+  $rsyncdest      = undef,
+  $rsyncport      = 22) {
 
   user { $name:
     comment    => $name,

--- a/spec/defines/dlrn_worker_spec.rb
+++ b/spec/defines/dlrn_worker_spec.rb
@@ -120,6 +120,16 @@ describe 'dlrn::worker' do
             is_expected.not_to contain_file("/usr/local/share/dlrn/#{user}/projects.ini")
             .with_content(/gerrit=$/)
         end
+
+        it 'does not set rsyncdest in projects.ini' do
+            is_expected.not_to contain_file("/usr/local/share/dlrn/#{user}/projects.ini")
+            .with_content(/rsyncdest=/)
+        end
+
+        it 'does set rsyncport to 22 in projects.ini' do
+            is_expected.to contain_file("/usr/local/share/dlrn/#{user}/projects.ini")
+            .with_content(/rsyncport=22$/)
+        end
       end
 
       context 'with specific uid' do
@@ -309,6 +319,28 @@ describe 'dlrn::worker' do
         is_expected.to contain_file("/usr/local/share/dlrn/centos-kilo/projects.ini")
         .with_content(/baseurl=http:\/\/trunk.rdoproject.org\/centos7-kilo$/)
     end
+  end
+
+  context 'with rsyncdest parameter parameter' do
+    before :each do
+      params.merge!(:rsyncdest       => 'centos-master@backupserver.example.com:/home/centos-master/data/repos')
+      params.merge!(:rsyncport       => 1022)
+    end
+
+    let :title do
+      'centos-mitaka'
+    end
+
+    it 'sets rsyncdest in projects.ini' do
+        is_expected.to contain_file("/usr/local/share/dlrn/centos-mitaka/projects.ini")
+        .with_content(/rsyncdest=centos-master@backupserver.example.com:\/home\/centos-master\/data\/repos$/)
+    end
+
+    it 'does set rsyncport to 1022 in projects.ini' do
+        is_expected.to contain_file("/usr/local/share/dlrn/centos-mitaka/projects.ini")
+        .with_content(/rsyncport=1022$/)
+    end
+
   end
 end
 

--- a/templates/projects.ini.erb
+++ b/templates/projects.ini.erb
@@ -9,4 +9,6 @@ target=<%= @target %>
 smtpserver=<%= @dlrn_mailserver %>
 reponame=delorean
 tags=<%= @release %>
+<% if @rsyncdest %>rsyncdest=<%= @rsyncdest %><% end %>
+<% if @rsyncport %>rsyncport=<%= @rsyncport %><% end %>
 <% if @gerrit_user %>gerrit=yes<% end %>


### PR DESCRIPTION
Added support for rsync push as per https://review.gerrithub.io/#/c/271544/

DLRN can now push the result dir to a remote server at the end of the build process.
This patch add options rsyncdest and rsyncport to projects.ini file in worker
defined type.

Fixes #15