### PR TITLE
Change default release to newton for master worker

### DIFF
--- a/examples/common.yaml
+++ b/examples/common.yaml
@@ -12,7 +12,7 @@ dlrn::workers:
     disable_email: *disable_email
     enable_cron: *enable_cron
     symlinks: ['/var/www/html/centos7', '/var/www/html/centos70', '/var/www/html/centos7-master']
-    release: 'mitaka'
+    release: 'newton'
 #   gerrit_user: 'rdo-trunk'
 #   gerrit_email: 'rdo-trunk@rdoproject.org'
 #   rsyncdest: 'centos-master@backupserver.example.com:/home/centos-master/data/repos'


### PR DESCRIPTION
Depends-on: https://github.com/redhat-openstack/rdoinfo/pull/164