### PR TITLE
Added support for passive server

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -13,3 +13,4 @@ fixtures:
     firewalld: git://github.com/crayfishx/puppet-firewalld.git
     wget: git://github.com/maestrodev/puppet-wget.git
     concat: git://github.com/puppetlabs/puppetlabs-concat.git
+    apache: git://github.com/puppetlabs/puppetlabs-apache.git

--- a/README.md
+++ b/README.md
@@ -86,6 +86,15 @@ The DLRN instance architecture includes a secondary server, where all repos are 
 ####`mock_tmpfs_enable`
 Enables the Mock TMPfs plugin. Note this will enable creation of a file system in RAM using up to 6 GB per worker, so be sure you have enough RAM and swap for all workers.
 
+####`server_type`
+Defines the server_type. It can be set to primary (default) or passive. Even when enabled in workers hiera configuration, passive servers will not enable:
+- cron jobs for run-dlrn.sh
+- rsync of new builds (they are suposed to be the destination of the synchronization)
+- Opening reviews in gerrit automatically on FTBFS
+- Sending mails on build failure
+Additionally, passive servers will redirect to buildlogs when users trying to access to current-passed-ci or current-tripleo
+
+
 ### Class: dlrn::common
 
 This class is used internally, to configure the common OS-specific aspects required by DLRN.
@@ -139,6 +148,9 @@ This class is used internally, to set up the Apache instance for DLRN and fetch 
 ```puppet
 class { 'dlrn::web' : }
 ```
+
+####`web_domain`
+Specifies the domain name used for the web server running in dlrn server.
 
 ### Define dlrn::lsyncdconfig
 
@@ -214,11 +226,15 @@ This is a user to run Gerrit reviews for packages after build failures. If set t
 ####`gerrit_email` 
 This is the email for the user to run Gerrit reviews for packages after build failures. It is required when `gerrit_user` is set, and ignored otherwise.
 
-###`rsyncdest`
+####`rsyncdest`
 This is the destination where builtdir and reports are replicated when build is ok in scp-like format. Defaults to `undef`, which means that replication is disabled.
 
-###`rsyncport`
+####`rsyncport`
 This is the port number for ssh in server where builtdir and reports are replicated. Defaults to `22`.
+
+####`server_type`
+This defines if the server where the worker is being configured is primary or passive (see explanation in Class: dlrn section). Defaults to the value defined
+
 
 ## Limitations
 

--- a/examples/common.yaml
+++ b/examples/common.yaml
@@ -2,6 +2,8 @@
 enable_worker_cronjobs: &enable_cron false
 disable_worker_email: &disable_email true
 
+dlrn::web::web_domain: 'trunk.rdoproject.org'
+
 dlrn::workers:
   centos-master:
     name: 'centos-master'

--- a/examples/passive.pp
+++ b/examples/passive.pp
@@ -1,0 +1,6 @@
+class { 'dlrn': 
+  sshd_port              => 3300,
+  mock_tmpfs_enable      => false,
+  server_type            => 'passive',
+}
+

--- a/examples/site.pp
+++ b/examples/site.pp
@@ -2,5 +2,6 @@ class { 'dlrn':
 #  backup_server          => 'testbackup.example.com',
   sshd_port              => 3300,
   mock_tmpfs_enable      => false,
+  server_type            => 'primary',
 }
 

--- a/manifests/common.pp
+++ b/manifests/common.pp
@@ -39,17 +39,11 @@ class dlrn::common (
 
   $required_packages = [ 'lvm2', 'xfsprogs', 'yum-utils', 'vim-enhanced',
                       'mock', 'rpm-build', 'git', 'python-pip',
-                      'python-virtualenv', 'httpd', 'gcc', 'createrepo',
+                      'python-virtualenv', 'gcc', 'createrepo',
                       'screen', 'python-tox', 'git-review', 'python-sh',
                       'postfix', 'lsyncd', 'firewalld', 'openssl-devel',
                       'libffi-devel' ]
   package { $required_packages: ensure => 'installed' }
-
-  service { 'httpd':
-    ensure  => 'running',
-    enable  => true,
-    require => Package['httpd'],
-  }
 
   service { 'postfix':
     ensure  => 'running',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,6 +17,14 @@
 #   (optional) Enable the mock tmpfs plugin. Note this requires a lot of RAM
 #   Defaults to false
 #
+# [*server_type*]
+#   (optional) server_type can be set to primary or passive. Primary server
+#   check periodically for changes in repos and synchronize every build to a
+#   passive server if rsync is enabled. Passive server receives builds from
+#   primary and redirects current-passed-ci and current-tripleo to buildlogs.
+#   Defaults to "Primary"
+#
+#
 # === Examples
 #
 #  class { 'dlrn': }
@@ -30,6 +38,7 @@ class dlrn (
   $sshd_port         = 3300,
   $backup_server     = undef,
   $mock_tmpfs_enable = false,
+  $server_type       = 'primary',
 ) {
 
   class { '::dlrn::common':

--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -2,10 +2,28 @@
 #
 #  This class sets up the web content for a DLRN instance
 #
+# === Parameters:
+#
+# [*web_domain*]
+#   (mandatory) domain name of the web server
+#   example: trunk.rdoproject.org
+#
 
 class dlrn::web(
+  $web_domain,
 ){
 
+  class { 'apache':
+    default_vhost => false,
+  }
+
+  apache::vhost { $web_domain:
+    port          => 80,
+    default_vhost => true,
+    override      => 'FileInfo',
+    docroot       => '/var/www/html',
+    servername    => 'default'
+  } ->
   wget::fetch { 'https://raw.githubusercontent.com/redhat-openstack/trunk.rdoproject.org/master/index.html':
     destination => '/var/www/html/index.html',
     cache_dir   => '/var/cache/wget',

--- a/metadata.json
+++ b/metadata.json
@@ -17,7 +17,9 @@
     {"name":"puppetlabs-lvm","version_requirement":">= 0.5.0"},
     {"name":"ceritsc-yum","version_requirement":">= 0.9.6"},
     {"name":"crayfishx-firewalld","version_requirement":">= 2.0.0"},
-    {"name":"maestrodev-wget","version_requirement":">= 1.7.1"}
+    {"name":"maestrodev-wget","version_requirement":">= 1.7.1"},
+    {"name":"puppetlabs-apache","version_requirement":">= 1.10.0"},
+    {"name":"puppetlabs-concat","version_requirement":">= 2.1.0"}
   ]
 }
 

--- a/spec/classes/dlrn_web_spec.rb
+++ b/spec/classes/dlrn_web_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'hiera'
 
 describe 'dlrn::web' do
   let :facts do
@@ -11,7 +12,26 @@ describe 'dlrn::web' do
       :processorcount         => 2 }
   end
 
+  let(:hiera_config) { 'spec/fixtures/hiera.yaml' }
+  hiera = Hiera.new(:config => 'spec/fixtures/hiera.yaml')
+
   context 'with default parameters' do
+    it 'installs httpd package' do
+      is_expected.to contain_package('httpd').with( :ensure => 'installed')
+      is_expected.not_to contain_package('mod_ssl')
+    end
+
+    it 'enables httpd service' do
+      is_expected.to contain_service('httpd').with(
+        :ensure  => 'running',
+        :enable  => 'true',
+      )
+    end
+
+    it 'enables http port' do
+      is_expected.to contain_apache__vhost('dummy.example.com').with(:port => 80)
+    end
+
     it 'creates /var/www/html/images' do
       is_expected.to contain_file('/var/www/html/images').with(
         :ensure  => 'directory',

--- a/spec/fixtures/hiera/default.yaml
+++ b/spec/fixtures/hiera/default.yaml
@@ -1,6 +1,7 @@
 ---
 enable_worker_cronjobs: &enable_cron false
 disable_worker_email: &disable_email true
+dlrn::web::web_domain: 'dummy.example.com'
 
 dlrn::workers:
   centos-master:

--- a/templates/htaccess.erb
+++ b/templates/htaccess.erb
@@ -1,0 +1,6 @@
+<% if @distro_branch == "master" %>
+RedirectMatch "^/(.*)/current-passed-ci" http://buildlogs.centos.org/centos/7/cloud/x86_64/rdo-trunk-master-tested 
+RedirectMatch "^/(.*)/current-tripleo" http://buildlogs.centos.org/centos/7/cloud/x86_64/rdo-trunk-master-tripleo
+<% else %>
+RedirectMatch "^/(.*)/current-passed-ci" http://buildlogs.centos.org/centos/7/cloud/x86_64/rdo-trunk-<%= @release %>-tested 
+<% end %>

--- a/templates/projects.ini.erb
+++ b/templates/projects.ini.erb
@@ -6,9 +6,11 @@ baseurl=http://trunk.rdoproject.org/<%= @baseurl_target %>
 distro=<%= @distgit_branch %>
 source=<%= @distro_branch %>
 target=<%= @target %>
-smtpserver=<%= @dlrn_mailserver %>
 reponame=delorean
 tags=<%= @release %>
+<% if @server_type == 'primary' %> 
+smtpserver=<%= @dlrn_mailserver %>
 <% if @rsyncdest %>rsyncdest=<%= @rsyncdest %><% end %>
 <% if @rsyncport %>rsyncport=<%= @rsyncport %><% end %>
 <% if @gerrit_user %>gerrit=yes<% end %>
+<% end %>


### PR DESCRIPTION
Currently, dlrn infra in RDO project is formed by two servers a
primary and a passive one. This commit adds proper support for both
servers to use the same hiera config file by creating a new parameter
server_type which can be set to primary (default) or passive.

Even when enabled in workers hiera configuration, passive servers will not enable:
- cron jobs for run-dlrn.sh
- rsync of new builds (they are suposed to be the destination of the synchronization)
- Opening reviews in gerrit automatically on FTBFS
- Sending mails on build failure
Additionally, passive servers will configure apache to redirect to buildlogs when users
trying to access to current-passed-ci or current-tripleo

Apache configuration moved to puppetlabs-apache as we need to adjust override
configuration for .htaccess files to work.