### PR TITLE
Add "smtpserver=" line for passive servers

### DIFF
--- a/spec/defines/dlrn_worker_spec.rb
+++ b/spec/defines/dlrn_worker_spec.rb
@@ -387,9 +387,9 @@ describe 'dlrn::worker' do
         .with_content(/gerrit=yes$/)
       end
 
-      it 'does not set smtpserver in projects.ini' do
-        is_expected.not_to contain_file("/usr/local/share/dlrn/#{title}/projects.ini")
-        .with_content(/smtpserver=/)
+      it 'sets empty smtpserver in projects.ini' do
+        is_expected.to contain_file("/usr/local/share/dlrn/#{title}/projects.ini")
+        .with_content(/smtpserver=$/)
       end
     end
 

--- a/templates/projects.ini.erb
+++ b/templates/projects.ini.erb
@@ -13,4 +13,6 @@ smtpserver=<%= @dlrn_mailserver %>
 <% if @rsyncdest %>rsyncdest=<%= @rsyncdest %><% end %>
 <% if @rsyncport %>rsyncport=<%= @rsyncport %><% end %>
 <% if @gerrit_user %>gerrit=yes<% end %>
+<% elsif @server_type == 'passive' %> 
+smtpserver=
 <% end %>


### PR DESCRIPTION
smtpserver parameter is required by dlrn even if it's empty.