### PR TITLE
Fixed issue when gerrit user is added to multiple workers

### DIFF
--- a/manifests/worker.pp
+++ b/manifests/worker.pp
@@ -334,18 +334,10 @@ python setup.py develop",
       require     => File["/home/${name}"],
     }
 
-    sshkey { "${name}-review.rdoproject.org":
+    ensure_resource('sshkey','review.rdoproject.org', {
       ensure  => present,
-      name    => 'review.rdoproject.org',
       type    => 'rsa',
       key     => 'AAAAB3NzaC1yc2EAAAADAQABAAABAQCcv42F0KURajhaHpXECtonyhyxyyIexl0eJvKCTnc6hCE2bf8Iymw/xQIxmIwoibFunSC74tZe2t7Zy+yf3nLeNgE3T8+79yNxA2N4cJuY1T51haE5T1LKTMEkPkA4ucS8Lvd7KiXeTWRqOUQtLDWiZSZxPILzlb13AQ1M2s4U3X0M7SBt4V27ezDe34OQbBHMAGVQOKZhQkNVp3e5gmMfPlE3FifjQ07RI2fyG8v/r4A8on9n/g8Ge0vbDyGR0Ejt314MJ9JpzQTSPzw05UkjJYE7Knw3sHyBU9qIFHEm1Gw4z0PukiuINUmnBDVkf9ep6IsIw4JSvzNQbaLO9t99',
-      target  => "/home/${name}/.ssh/known_hosts",
-      require => File["/home/${name}"],
-    } ->
-    file { "/home/${name}/.ssh/known_hosts":
-      mode  => '0644',
-      owner => $name,
-      group => $name,
-    }
+    })
   }
 }

--- a/spec/defines/dlrn_worker_spec.rb
+++ b/spec/defines/dlrn_worker_spec.rb
@@ -259,10 +259,9 @@ describe 'dlrn::worker' do
         end
 
         it 'sets up the required SSH keys' do
-          is_expected.to contain_sshkey("#{user}-review.rdoproject.org").with(
+          is_expected.to contain_sshkey('review.rdoproject.org').with(
             :ensure => 'present',
             :name   => 'review.rdoproject.org',
-            :target => "/home/#{user}/.ssh/known_hosts",
           )
         end
       end


### PR DESCRIPTION
When gerrit is enabled in multiple workers, duplicated resource
sshkey error arises and sshkey is not applied.

This patch install ssh key at host level instead of at user level
with ensure_resource to avoid duplicate resources.